### PR TITLE
Enable unsecure Node.js version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: write
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
 jobs:
   build:
     runs-on: [self-hosted, Ubuntu18]


### PR DESCRIPTION
Allow the use of unsecure Node.js version in GitHub Actions.